### PR TITLE
Changed package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,24 @@
 
 from setuptools import setup
 
+
+def parse_requirements(filename):
+    return list(filter(lambda line: (line.strip())[0] != '#',
+                      [line.strip() for line in open(filename).readlines()]))
+
+
+requirements = parse_requirements('requirements.txt')
+
 setup(
-        name='beatport',
+        name='beatport-api',
         version='0.0.1',
         description='Handles authentication for the Beatport API',
         url='https://github.com/jsakas/beatport',
         author='jsakas',
         author_email='jpsakas@gmail.com',
-        install_requires=[
-            'rauth','requests'
-            ],
+        license='MIT',
+        install_requires=requirements,
         py_modules=[
-            'beatport'
+            'beatport-api'
             ],
         )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 
 def parse_requirements(filename):
-    return list(filter(lambda line: (line.strip())[0] != '#',
+    return list(filter(lambda line: (len(line) != 0 and line.strip()[0] != '#'),
                       [line.strip() for line in open(filename).readlines()]))
 
 


### PR DESCRIPTION
A package already exists on pypi [named 'beatport'](https://pypi.python.org/pypi/beatport) meaning this package cannot be published.

At the same time I noticed all the requirements were not present in the setup file, so I added an automated parser.

Finally, without a license, this can't be used to so I suggest MIT, but open to suggestions.
